### PR TITLE
Fix for upstream changes to BGP library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.4
+- 1.8.1
 install:
 - go get ./...
 - go get -t ./...

--- a/zmrt/mrt.go
+++ b/zmrt/mrt.go
@@ -244,7 +244,7 @@ func MrtPathIterate(filename string, cb mrtPathCallback) error {
 					out.Attributes.OriginatorId = orgId.Value
 				} else if origin, ok := a.(*bgp.PathAttributeOrigin); ok {
 					var typ string
-					switch origin.Value[0] {
+					switch origin.Value {
 					case bgp.BGP_ORIGIN_ATTR_TYPE_IGP:
 						typ = "igp"
 					case bgp.BGP_ORIGIN_ATTR_TYPE_EGP:


### PR DESCRIPTION
Fix for #8 -- https://github.com/osrg/gobgp/commit/7a3cc616c3126bff5245c7a97d7fbe2904a67a24#diff-edc4c63655c0080e1c8f6d1feeef9461 removed `Value []byte` from `PathAttribute`, and added `Value uint8` to `PathAttributeOrigin`.
