### PR TITLE
Fix IP address parse error via trim of trailing newline character w/in AnnotateRead

### DIFF
--- a/annotate.go
+++ b/annotate.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/oschwald/geoip2-golang"
@@ -67,7 +68,7 @@ func AnnotateRead(path string, in chan<- string) {
 	r := bufio.NewReader(f)
 	line, err := r.ReadString('\n')
 	for err == nil {
-		in <- line
+		in <- strings.TrimSuffix(line, "\n")
 		line, err = r.ReadString('\n')
 	}
 	if err != nil && err != io.EOF {


### PR DESCRIPTION
With the merge of https://github.com/zmap/zannotate/pull/12, we changed how `AnnotateRead` reads in its input with the side-effect of including a trailing `\n` character. This results in an error down stream when [trying to parse the IP address][1], causing our pipeline to error with this fatal message:

```
time="2018-04-10T08:00:52-04:00" level=fatal msg="invalid IP received: 104.70.48.35\n"
```

Note, there might be some better idioms for this string read, but for now this commit is just trying to address the error.

[1]: https://github.com/zmap/zannotate/blob/8644b7ec3cac30cbd55b979a04c04b817b15abac/annotate.go#L136-L139

## Notes & Caveats

I have not run this code locally, and there is no test coverage.