### PR TITLE
Support for Readers returning partial Reads

### DIFF
--- a/cmd/mrt2json/main.go
+++ b/cmd/mrt2json/main.go
@@ -53,7 +53,7 @@ func raw(conf *MRT2JsonGlobalConf, f *os.File) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	zmrt.MrtRawIterate(inputFile, func(msg *mrt.MRTMessage) error {
+	err = zmrt.MrtRawIterate(inputFile, func(msg *mrt.MRTMessage) error {
 		if msg.Header.Type != mrt.TABLE_DUMPv2 {
 			log.Fatal("not an MRT TABLE_DUMPv2")
 		}
@@ -108,6 +108,9 @@ func raw(conf *MRT2JsonGlobalConf, f *os.File) {
 		}
 		return nil
 	})
+	if err != nil {
+		log.Fatalf("Error processing input file '%s': %v", conf.InputFilePath, err)
+	}
 }
 
 func paths(conf *MRT2JsonGlobalConf, f *os.File) {
@@ -115,11 +118,14 @@ func paths(conf *MRT2JsonGlobalConf, f *os.File) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	zmrt.MrtPathIterate(inputFile, func(msg *zmrt.RIBEntry) {
+	err = zmrt.MrtPathIterate(inputFile, func(msg *zmrt.RIBEntry) {
 		json, _ := json.Marshal(msg)
 		f.WriteString(string(json))
 		f.WriteString("\n")
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {


### PR DESCRIPTION
Previously, if `io.Read` did not return the full amount of requested data, there was a parse error that caused the parsing to silently stop.

This wraps the raw reader in a buffered reader, and uses the standard `io.ReadFull` command to ensure that the entire header is read.

Further, errors are now passed back to the caller rather than being dropped.