### PR TITLE
Add ability to filter out internal BGP ASes in paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.13
 
 require (
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 // indirect
+	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.9
 	github.com/oschwald/geoip2-golang v1.4.0
 	github.com/osrg/gobgp v2.0.0+incompatible
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.5.0
 	github.com/zmap/go-iptree v0.0.0-20170831022036-1948b1097e25
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56/go.mod h1:8BhOLuq
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -18,6 +20,8 @@ github.com/oschwald/maxminddb-golang v1.6.0 h1:KAJSjdHQ8Kv45nFIbtoLGrGWqHFajOIm7
 github.com/oschwald/maxminddb-golang v1.6.0/go.mod h1:DUJFucBg2cvqx42YmDa/+xHvb0elJtOm3o4aFQ/nb/w=
 github.com/osrg/gobgp v2.0.0+incompatible h1:91ARQbE1AtO0U4TIxHPJ7wYVZIqduyBwS1+FjlHlmrY=
 github.com/osrg/gobgp v2.0.0+incompatible/go.mod h1:vGVJPLW6JFDD7WA1vJsjB8OKmbbC2TKwHtr90CZS/u4=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
@@ -32,7 +36,11 @@ github.com/zmap/go-iptree v0.0.0-20170831022036-1948b1097e25/go.mod h1:qOasALtPB
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191224085550-c709ea063b76 h1:Dho5nD6R3PcW2SH1or8vS0dszDaXRxIw55lBX7XiE5g=
 golang.org/x/sys v0.0.0-20191224085550-c709ea063b76/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/zrouting/routinglookup_test.go
+++ b/zrouting/routinglookup_test.go
@@ -1,0 +1,59 @@
+package zrouting
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type pathFilterTest struct {
+	path     []uint32
+	filter   PathFilter
+	expected []uint32
+}
+
+// 64512 - 65534
+
+func TestIBGPFilter(t *testing.T) {
+	tests := []pathFilterTest{
+		pathFilterTest{
+			path:     []uint32{1, 2, 3, 4},
+			filter:   IdentityPathFilter,
+			expected: []uint32{1, 2, 3, 4},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 65000, 38},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 38},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 65000},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 38},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 65000, 64512, 65118, 38, 27},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 38, 27},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 65000, 64512, 65118},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 38},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 2, 2, 64512, 64512, 38, 3, 3},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 2, 2, 38, 3, 3},
+		},
+		pathFilterTest{
+			path:     []uint32{1, 2, 2, 64512, 64512, 3, 3},
+			filter:   InternalBGPPathFilter(38),
+			expected: []uint32{1, 2, 2, 38, 3, 3},
+		},
+	}
+	for _, test := range tests {
+		actual := test.filter(test.path)
+		assert.DeepEqual(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
This should make any sequence of internal ASes appear as a single "origin" AS, and correctly handle the case where the origin is already in the path.