### PR TITLE
Added BGP AFI for IPv6 support in routing lookup

### DIFF
--- a/zrouting/routinglookup.go
+++ b/zrouting/routinglookup.go
@@ -83,7 +83,7 @@ func InternalBGPPathFilter(origin uint32) PathFilter {
 func (t *RoutingLookupTree) PopulateFromMRTFiltered(raw io.Reader, pathFilter PathFilter) {
 	t.IPTree = iptree.New()
 	zmrt.MrtPathIterate(raw, func(e *zmrt.RIBEntry) {
-		if e.AFI == bgp.AFI_IP {
+		if e.AFI == bgp.AFI_IP || e.AFI == bgp.AFI_IP6 {
 			var n ASTreeNode
 			n.Prefix = e.Prefix
 			n.Path = pathFilter(e.Attributes.ASPath)


### PR DESCRIPTION
Currently, the routing lookup process populates the MRT table only if the AFI (Address Family Identifier) for each entry is IPv4. This PR adds support for IPv6 by also checking if the entry has an IPv6 AFI representation. Arbitrary tests show that no other changes are needed to support IPv6.