### PR TITLE
Fix regression introduced with Routing module and add MRT download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ echo "1.1.1.1" | zannotate --geoasn --geoasn-database=/path-to-downloaded-file/G
 {"ip":"1.1.1.1","geoasn":{"asn":13335,"org":"CLOUDFLARENET"}}
 ```
 
+### BGP Routing Tables
+1. Go to [https://archive.routeviews.org/route-views2/bgpdata/](https://archive.routeviews.org/route-views2/bgpdata/)
+2. Select a month directory (e.g. `2025.09`)
+3. Select the `RIBS/` directory
+4. Download a BZiped MRT file (e.g. `rib.20250923.1200.bz2`)
+5. Unzip the file with:
+
+```shell
+bzip2 -d ./path-to-downloaded-file/rib.20250923.1200.bz2
+```
+
+6. Test with:
+
+```shell
+echo "1.1.1.1" | ./zannotate --routing --routing-mrt-file=/tmp/rib.20250923.1200
+```
+
+```json
+{"ip":"1.1.1.1","routing":{"prefix":"1.1.1.0/24","asn":13335,"path":[3561,209,3356,13335]}}
+```
+
 # Input/Output
 
 ## Output

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/osrg/gobgp/v3 v3.37.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837
+	github.com/zmap/go-iptree v0.0.0-20251001212402-0a55a77d6804
 	github.com/zmap/zdns/v2 v2.0.5
 	gotest.tools/v3 v3.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/zmap/go-dns-root-anchors v0.0.0-20250415191259-6d65fb878756 h1:yeprVD
 github.com/zmap/go-dns-root-anchors v0.0.0-20250415191259-6d65fb878756/go.mod h1:W5CEzaf+B3Pg1hzUQotwQ2EBg7jB49DkmKuiNuWPO80=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837 h1:DjHnADS2r2zynZ3WkCFAQ+PNYngMSNceRROi0pO6c3M=
 github.com/zmap/go-iptree v0.0.0-20210731043055-d4e632617837/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=
+github.com/zmap/go-iptree v0.0.0-20251001212402-0a55a77d6804 h1:jcY3/CdJnd4A5bO3m5ebZyV533Owz8A6NlDoWE/WQgQ=
+github.com/zmap/go-iptree v0.0.0-20251001212402-0a55a77d6804/go.mod h1:9vp0bxqozzQwcjBwenEXfKVq8+mYbwHkQ1NF9Ap0DMw=
 github.com/zmap/zcrypto v0.0.0-20250416162916-8ff8dfaa718d h1:QcrqQ8a285ozWrRrsPUtYl4y+9YJAM4gSTF3EQDTQk8=
 github.com/zmap/zcrypto v0.0.0-20250416162916-8ff8dfaa718d/go.mod h1:Zz4/7kyRgJXC+PTpLV4tIgaCMTHWnNbgOLZoXuVrkws=
 github.com/zmap/zdns/v2 v2.0.5 h1:RNrKZWki/LzKIXiHcO3oJwVM0mXkwu5mNs5s3Phniy0=

--- a/zrouting/routinglookup.go
+++ b/zrouting/routinglookup.go
@@ -92,7 +92,8 @@ func (t *RoutingLookupTree) PopulateFromMRTFiltered(raw io.Reader, pathFilter Pa
 			if len(n.Path) > 0 {
 				n.ASN = n.Path[len(n.Path)-1]
 			}
-			err := t.IPTree.AddByString(e.Prefix, n)
+			// Set the node in the tree
+			err := t.IPTree.SetByString(e.Prefix, n)
 			if err != nil {
 				return fmt.Errorf("could not add prefix %s to IP tree: %w", e.Prefix, err)
 			}


### PR DESCRIPTION
Back in June I added some linters to ZAnnotate and as part of that, return an error here that was otherwise silently discarded.

While seemingly innocuous, this caused ZAnnotate to error out with a MRT table downloaded from routeviews.org.

The reason is that the `iptree.AddByString` will error if another entry is present for that subnet. This causes issues when there are multiple paths to a subnet from a given vantage point.

I figure the best solution is I added the underlying library's `SetByString` to `iptree`, and use that. This way we still preserve the prior behavior of returning A route to the subnet, however instead of it being the first one (and the subsequent additions silently erroring), we'll return the last one, since each addition will overwrite the first.