### PR TITLE
Add a per-second status updates

### DIFF
--- a/annotate.go
+++ b/annotate.go
@@ -18,7 +18,9 @@ import (
 	"bufio"
 	"encoding/csv"
 	"fmt"
+	"os/signal"
 	"slices"
+	"syscall"
 	"time"
 
 	"io"
@@ -262,55 +264,78 @@ func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 	wg.Done()
 }
 
+// PerSecondUpdateWorker prints a per-second scan summary as well as a Scan Completed/Aborted msg at the end
+// It writes the updates to the file path provided, or stderr if the file path is empty or "-".
+// For every line of output received on outChan, it counts one IP annotated
 func PerSecondUpdateWorker(filePath string, outChan <-chan string, wg *sync.WaitGroup) {
+	const (
+		scanCompleteStatusMsg = "Scan Complete; "
+		scanAbortedStatusMsg = "Scan Aborted; "
+		perSecondStatusMsg = ""
+	)
 	log.Debug("PerSecondUpdateWorker started")
 	defer wg.Done()
 	f := os.Stderr
-	if filePath != "-" && filePath != "" {
+	userProvidedFilePath := filePath != "-" && filePath != ""
+	if userProvidedFilePath {
 		var err error
-		f, err = os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
+		f, err = os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 		if err != nil {
 			log.Fatalf("unable to open per-second log file: %s", err.Error())
 		}
 		defer f.Close()
 	}
 	startTime := time.Now()
-	ticker := time.NewTicker(time.Second)
 	ipsAnnotated := 0
+	getLogMessage := func(scanStatus string) string {
+		timeSinceStart := time.Since(startTime)
+		return fmt.Sprintf("%02dh:%02dm:%02ds; %s%d ips annotated; %.02f ips/sec\n",
+			int(timeSinceStart.Hours()),
+			int(timeSinceStart.Minutes())%60,
+			int(timeSinceStart.Seconds())%60,
+			scanStatus, // empty string for per-second updates and Scan Complete/Aborted for the relevant circumstance
+			ipsAnnotated,
+			float64(ipsAnnotated)/timeSinceStart.Seconds())
+	}
+	monitorForInterrupt := func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		sigNum := <-sigs // SIGINT or SIGTERM received
+		_, err := f.WriteString(getLogMessage(scanAbortedStatusMsg))
+		if err != nil {
+			log.Fatalf("unable to write to log file: %v", err)
+		}
+		if userProvidedFilePath {
+			err = f.Sync() // User provided an actual file to log to, let's flush it to disk before exiting
+			if err != nil {
+				log.Fatalf("unable to write to log file: %v", err)
+			}
+		}
+		os.Exit(128 + int(sigNum.(syscall.Signal)))
+	}
+	go monitorForInterrupt()
+	// Now for the per-second, usual status update loop
+	ticker := time.NewTicker(time.Second)
 	for {
 		select {
 		case <-ticker.C:
 			// Print per-second output summary
-			timeSinceStart := time.Since(startTime)
-			s := fmt.Sprintf("%02dh:%02dm:%02ds; %d ips annotated; %.02f ips/sec\n",
-				int(timeSinceStart.Hours()),
-				int(timeSinceStart.Minutes())%60,
-				int(timeSinceStart.Seconds())%60,
-				ipsAnnotated,
-				float64(ipsAnnotated)/timeSinceStart.Seconds())
-			_, err := f.WriteString(s)
+			_, err := f.WriteString(getLogMessage(perSecondStatusMsg))
 			if err != nil {
 				log.Fatalf("unable to write to log file: %v", err)
 			}
 		case _, ok := <-outChan:
 			if !ok {
-				timeSinceStart := time.Since(startTime)
-				s := fmt.Sprintf("%02dh:%02dm:%02ds; Scan Complete; %d ips annotated; %.02f ips/sec\n",
-					int(timeSinceStart.Hours()),
-					int(timeSinceStart.Minutes())%60,
-					int(timeSinceStart.Seconds())%60,
-					ipsAnnotated,
-					float64(ipsAnnotated)/timeSinceStart.Seconds())
-				_, err := f.WriteString(s)
+				_, err := f.WriteString(getLogMessage(scanCompleteStatusMsg))
 				if err != nil {
 					log.Fatalf("unable to write to log file: %v", err)
 				}
 				return
 			}
+			// IP annotated on the outbound channel
 			ipsAnnotated++
 		}
 	}
-
 }
 
 func DoAnnotation(conf *GlobalConf) {
@@ -368,7 +393,7 @@ func DoAnnotation(conf *GlobalConf) {
 	encodedOut, updatesOut := Tee[string](pipedEncodedOut)
 	go AnnotateWrite(conf.OutputFilePath, encodedOut, &writeWG)
 	writeWG.Add(1)
-	go PerSecondUpdateWorker(conf.LogFilePath, updatesOut, &writeWG)
+	go PerSecondUpdateWorker(conf.StatusUpdatesFilePath, updatesOut, &writeWG)
 	writeWG.Add(1)
 	// all workers started. close out everything in a safe order
 	// inRaw: we don't need to wait on this because it'll close its own channel

--- a/annotate.go
+++ b/annotate.go
@@ -270,8 +270,8 @@ func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 func PerSecondUpdateWorker(filePath string, outChan <-chan string, wg *sync.WaitGroup) {
 	const (
 		scanCompleteStatusMsg = "Scan Complete; "
-		scanAbortedStatusMsg = "Scan Aborted; "
-		perSecondStatusMsg = ""
+		scanAbortedStatusMsg  = "Scan Aborted; "
+		perSecondStatusMsg    = ""
 	)
 	log.Debug("PerSecondUpdateWorker started")
 	defer wg.Done()
@@ -283,7 +283,12 @@ func PerSecondUpdateWorker(filePath string, outChan <-chan string, wg *sync.Wait
 		if err != nil {
 			log.Fatalf("unable to open per-second log file: %s", err.Error())
 		}
-		defer f.Close()
+		defer func(f *os.File) {
+			err := f.Close()
+			if err != nil {
+				log.Fatalf("unable to close per-second log file: %s", err.Error())
+			}
+		}(f)
 	}
 	startTime := time.Now()
 	ipsAnnotated := 0

--- a/annotate.go
+++ b/annotate.go
@@ -17,7 +17,9 @@ package zannotate
 import (
 	"bufio"
 	"encoding/csv"
+	"fmt"
 	"slices"
+	"time"
 
 	"io"
 	"net"
@@ -103,6 +105,22 @@ func csvToInProcess(record []string, headers []string, ipFieldName, annotationFi
 
 	retv.Out = outMap
 	return retv
+}
+
+func Tee[T any](in <-chan T) (<-chan T, <-chan T) {
+	out1 := make(chan T)
+	out2 := make(chan T)
+
+	go func() {
+		defer close(out1)
+		defer close(out2)
+		for val := range in {
+			out1 <- val
+			out2 <- val
+		}
+	}()
+
+	return out1, out2
 }
 
 // single worker that reads from file and queues raw lines
@@ -244,6 +262,57 @@ func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 	wg.Done()
 }
 
+func PerSecondUpdateWorker(filePath string, outChan <-chan string, wg *sync.WaitGroup) {
+	log.Debug("PerSecondUpdateWorker started")
+	defer wg.Done()
+	f := os.Stderr
+	if filePath != "-" && filePath != "" {
+		var err error
+		f, err = os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			log.Fatalf("unable to open per-second log file: %s", err.Error())
+		}
+		defer f.Close()
+	}
+	startTime := time.Now()
+	ticker := time.NewTicker(time.Second)
+	ipsAnnotated := 0
+	for {
+		select {
+		case <-ticker.C:
+			// Print per-second output summary
+			timeSinceStart := time.Since(startTime)
+			s := fmt.Sprintf("%02dh:%02dm:%02ds; %d ips annotated; %.02f ips/sec\n",
+				int(timeSinceStart.Hours()),
+				int(timeSinceStart.Minutes())%60,
+				int(timeSinceStart.Seconds())%60,
+				ipsAnnotated,
+				float64(ipsAnnotated)/timeSinceStart.Seconds())
+			_, err := f.WriteString(s)
+			if err != nil {
+				log.Fatalf("unable to write to log file: %v", err)
+			}
+		case _, ok := <-outChan:
+			if !ok {
+				timeSinceStart := time.Since(startTime)
+				s := fmt.Sprintf("%02dh:%02dm:%02ds; Scan Complete; %d ips annotated; %.02f ips/sec\n",
+					int(timeSinceStart.Hours()),
+					int(timeSinceStart.Minutes())%60,
+					int(timeSinceStart.Seconds())%60,
+					ipsAnnotated,
+					float64(ipsAnnotated)/timeSinceStart.Seconds())
+				_, err := f.WriteString(s)
+				if err != nil {
+					log.Fatalf("unable to write to log file: %v", err)
+				}
+				return
+			}
+			ipsAnnotated++
+		}
+	}
+
+}
+
 func DoAnnotation(conf *GlobalConf) {
 	// let each enabled annotator do their global initialization
 	// before we ask them to generate threa Annotators
@@ -290,13 +359,16 @@ func DoAnnotation(conf *GlobalConf) {
 	}
 	// encode raw data
 	var encodeWG sync.WaitGroup
-	encodedOut := make(chan string)
+	pipedEncodedOut := make(chan string)
 	for i := 0; i < conf.OutputEncodeThreads; i++ {
-		go AnnotateOutputEncode(conf, lastChannel, encodedOut, &encodeWG, i)
+		go AnnotateOutputEncode(conf, lastChannel, pipedEncodedOut, &encodeWG, i)
 		encodeWG.Add(1)
 	}
 	var writeWG sync.WaitGroup
+	encodedOut, updatesOut := Tee[string](pipedEncodedOut)
 	go AnnotateWrite(conf.OutputFilePath, encodedOut, &writeWG)
+	writeWG.Add(1)
+	go PerSecondUpdateWorker(conf.LogFilePath, updatesOut, &writeWG)
 	writeWG.Add(1)
 	// all workers started. close out everything in a safe order
 	// inRaw: we don't need to wait on this because it'll close its own channel
@@ -311,7 +383,7 @@ func DoAnnotation(conf *GlobalConf) {
 	}
 	// wait for the encoders
 	encodeWG.Wait()
-	close(encodedOut)
+	close(pipedEncodedOut)
 	// wait on writing to file
 	writeWG.Wait()
 	//endTime := time.Now().Format(time.RFC3339)

--- a/annotate.go
+++ b/annotate.go
@@ -109,7 +109,9 @@ func csvToInProcess(record []string, headers []string, ipFieldName, annotationFi
 	return retv
 }
 
-func Tee[T any](in <-chan T) (<-chan T, <-chan T) {
+// tee takes an input channel and returns two output channels that will both receive the same data as the input channel.
+// The output channels will be closed when the input channel is closed and all data has been processed.
+func tee[T any](in <-chan T) (<-chan T, <-chan T) {
 	out1 := make(chan T)
 	out2 := make(chan T)
 
@@ -331,6 +333,7 @@ func PerSecondUpdateWorker(filePath string, outChan <-chan string, wg *sync.Wait
 			}
 		case _, ok := <-outChan:
 			if !ok {
+				// output channel closed, scan complete
 				_, err := f.WriteString(getLogMessage(scanCompleteStatusMsg))
 				if err != nil {
 					log.Fatalf("unable to write to log file: %v", err)
@@ -395,7 +398,7 @@ func DoAnnotation(conf *GlobalConf) {
 		encodeWG.Add(1)
 	}
 	var writeWG sync.WaitGroup
-	encodedOut, updatesOut := Tee[string](pipedEncodedOut)
+	encodedOut, updatesOut := tee[string](pipedEncodedOut)
 	go AnnotateWrite(conf.OutputFilePath, encodedOut, &writeWG)
 	writeWG.Add(1)
 	go PerSecondUpdateWorker(conf.StatusUpdatesFilePath, updatesOut, &writeWG)

--- a/cmd/mrt2json/main.go
+++ b/cmd/mrt2json/main.go
@@ -153,8 +153,8 @@ func main() {
 	flags := flag.NewFlagSet("flags", flag.ExitOnError)
 	flags.StringVar(&conf.InputFilePath, "input-file", "", "path to MRT file")
 	flags.StringVar(&conf.OutputFilePath, "output-file", "-", "where should JSON output be saved")
-	flags.StringVar(&conf.LogFilePath, "log-file", "", "where should JSON output be saved")
-	flags.IntVar(&conf.Verbosity, "verbosity", 3, "where should JSON output be saved")
+	flags.StringVar(&conf.LogFilePath, "log-file", "", "where should logs be saved, defaults to stderr")
+	flags.IntVar(&conf.Verbosity, "verbosity", 3, "controls the verbosity of logs, 1 for fatal only, 2 for errors, 3 for warnings (default), 4 for info, and 5 for debug")
 
 	if len(os.Args) < 2 {
 		log.Fatalf("No command provided. Must choose raw or entries")

--- a/cmd/zannotate/main.go
+++ b/cmd/zannotate/main.go
@@ -30,10 +30,11 @@ func main() {
 	flags := flag.NewFlagSet("flags", flag.ExitOnError)
 	flags.StringVar(&conf.InputFilePath, "input-file", "-", "ip addresses to read")
 	flags.StringVar(&conf.InputFileType, "input-file-type", "ips", "ips, csv, json")
-	flags.StringVar(&conf.OutputFilePath, "output-file", "-", "where should JSON output be saved")
+	flags.StringVar(&conf.OutputFilePath, "output-file", "-", "where should JSON output be saved, defaults to stdout")
 	flags.StringVar(&conf.MetadataFilePath, "metadata-file", "",
 		"where should JSON metadata be saved")
-	flags.StringVar(&conf.LogFilePath, "log-file", "", "where should JSON logs be saved")
+	flags.StringVar(&conf.LogFilePath, "log-file", "", "where should logs be saved, defaults to stderr")
+	flags.StringVar(&conf.StatusUpdatesFilePath, "status-file", "", "where should per-second status updates be saved, defaults to stderr")
 	flags.IntVar(&conf.Verbosity, "verbosity", 3, "log verbosity: 1 (lowest)--5 (highest)")
 	// json annotation configuration
 	flags.StringVar(&conf.InputIPFieldName, "input-ip-field", "ip", "key in JSON or column in CSV that contains IP address")

--- a/conf.go
+++ b/conf.go
@@ -50,6 +50,7 @@ type GlobalConf struct {
 	OutputFilePath            string
 	MetadataFilePath          string
 	LogFilePath               string
+	StatusUpdatesFilePath     string
 	Verbosity                 int
 	Threads                   int
 	InputIPFieldName          string


### PR DESCRIPTION
Similar to `zdns` and `zgrab2`, this PR adds a per-second status update logged to `stderr`, by default.

While this won't let us give users and ETA of annotation completion, it's a helpful signal if users know how many IPs they're attempting to annotate and in any case provides a UX affordance that `zannotate` is making progress.
##Changes

### New Flag
```shell
  -status-file string
        where should per-second status updates be saved, defaults to stderr
```

### Scan Complete
```shell
shuf -n 100 input.txt | ./zannotate --rdns > /dev/null                                                                                                           12:20:24
00h:00m:01s; 85 ips annotated; 84.98 ips/sec
00h:00m:02s; 94 ips annotated; 46.99 ips/sec
00h:00m:03s; 96 ips annotated; 32.00 ips/sec
00h:00m:04s; 97 ips annotated; 24.25 ips/sec
00h:00m:05s; 97 ips annotated; 19.40 ips/sec
00h:00m:06s; 98 ips annotated; 16.33 ips/sec
00h:00m:07s; 99 ips annotated; 14.14 ips/sec
00h:00m:07s; Scan Complete; 100 ips annotated; 14.21 ips/sec
```

### Scan Aborted
```shell
shuf -n 1000 input.txt | ./zannotate --rdns > /dev/null                                                                                                          12:20:18
00h:00m:01s; 177 ips annotated; 176.95 ips/sec
00h:00m:02s; 358 ips annotated; 178.99 ips/sec
00h:00m:03s; 564 ips annotated; 187.96 ips/sec
00h:00m:04s; 725 ips annotated; 181.24 ips/sec
^C00h:00m:04s; Scan Aborted; 809 ips annotated; 178.78 ips/sec
```