### PR TITLE
Prevent modules from returning a nil result

### DIFF
--- a/annotate.go
+++ b/annotate.go
@@ -253,7 +253,7 @@ func isPtrNil(i any) bool {
 	}
 	val := reflect.ValueOf(i)
 	switch val.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
+	case reflect.Pointer, reflect.Interface, reflect.Slice, reflect.Map:
 		return val.IsNil()
 	default:
 		return false
@@ -272,14 +272,14 @@ func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 		if fieldName != "" && slices.Contains([]string{"json", "csv"}, conf.InputFileType) {
 			p := inProcess.Out[fieldName].(map[string]interface{})
 			res := a.Annotate(inProcess.Ip)
-			if isPtrNil(res){
+			if isPtrNil(res) {
 				res = struct{}{} // Don't return null, breaks downstream JSON parsing
 			}
 			p[name] = res
 
 		} else {
 			res := a.Annotate(inProcess.Ip)
-			if isPtrNil(res){
+			if isPtrNil(res) {
 				res = struct{}{} // Don't return null, breaks downstream JSON parsing
 			}
 			inProcess.Out[name] = res

--- a/annotate.go
+++ b/annotate.go
@@ -19,6 +19,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os/signal"
+	"reflect"
 	"slices"
 	"syscall"
 	"time"
@@ -246,6 +247,19 @@ func AnnotateWrite(path string, out <-chan string, wg *sync.WaitGroup) {
 	log.Debug("write thread finished")
 }
 
+func isPtrNil(i any) bool {
+	if i == nil {
+		return true
+	}
+	val := reflect.ValueOf(i)
+	switch val.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
+		return val.IsNil()
+	default:
+		return false
+	}
+}
+
 func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 	outChan chan<- inProcessIP, fieldName string, wg *sync.WaitGroup, i int) {
 	name := a.GetFieldName()
@@ -257,9 +271,18 @@ func AnnotateWorker(conf *GlobalConf, a Annotator, inChan <-chan inProcessIP,
 	for inProcess := range inChan {
 		if fieldName != "" && slices.Contains([]string{"json", "csv"}, conf.InputFileType) {
 			p := inProcess.Out[fieldName].(map[string]interface{})
-			p[name] = a.Annotate(inProcess.Ip)
+			res := a.Annotate(inProcess.Ip)
+			if isPtrNil(res){
+				res = struct{}{} // Don't return null, breaks downstream JSON parsing
+			}
+			p[name] = res
+
 		} else {
-			inProcess.Out[name] = a.Annotate(inProcess.Ip)
+			res := a.Annotate(inProcess.Ip)
+			if isPtrNil(res){
+				res = struct{}{} // Don't return null, breaks downstream JSON parsing
+			}
+			inProcess.Out[name] = res
 		}
 		outChan <- inProcess
 	}

--- a/censys.go
+++ b/censys.go
@@ -83,7 +83,6 @@ var censysAPIHostLookupURL = "https://api.platform.censys.io/v3/global/asset/hos
 // Annotate performs a Censys host lookup for the given IP address and returns the results.
 // If an error occurs or a lookup fails, it returns nil
 func (a *CensysAnnotator) Annotate(ip net.IP) interface{} {
-
 	req, err := http.NewRequest("GET", censysAPIHostLookupURL+ip.String(), nil)
 	if err != nil {
 		// If we can't even form a request, we'll fail to enrich anything. Erroring out.


### PR DESCRIPTION
It's common when we run into an error when annotating to 1) log 2) return nil so that downstream parsers don't get a half-created result with no indication that something has gone wrong.

However, our modules were split between returning an empty result or nil, this PR adds a check in `annotate.go` so any nil results will be converted to an empty struct, thereby streamlining downstream processing:

Example:
```shell
echo "127.0.0.123" |  ./zannotate --censys --censys-pat="censys_xxxxXXXXXxxxxxx" --rdns --routing --routing-mrt-file=./data-snapshots/routing.mrt
{"ip":"127.0.0.123","censys":{},"rdns":{},"routing":{}}
```

## Related Issues
Closes #78 